### PR TITLE
Added option to pass custom parameters to ngrok

### DIFF
--- a/valet
+++ b/valet
@@ -46,7 +46,7 @@ then
 
     # Fetch Ngrok URL In Background...
     bash "$DIR/cli/scripts/fetch-share-url.sh" &
-    sudo -u $(logname) "$DIR/bin/ngrok" http -host-header=rewrite "$HOST.$DOMAIN:80"
+    sudo -u $(logname) "$DIR/bin/ngrok" http "$HOST.$DOMAIN:80" -host-header=rewrite ${*:2}
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool


### PR DESCRIPTION
This makes it possible to add custom parameters to ngrok. For example:
--region=eu
-subdomain=YOUR_SUBDOMAIN

Some features, like -subdomain, are only available with the paid version of Ngrok.

Usage: valet share --region=eu --subdomain=your_custom_domain